### PR TITLE
feat: support migration '.mjs' file extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Options:
 
 Commands:
   migrate                     Migrates the database to the newest migration.
-  create                      Creates a new migration
+  create [options]            Creates a new migration. [--mjs] option to use '.mjs' file extension.
   revert [options] <version>  Reverts the database to the given migration ID's state
   list                        Shows a list of the migrations (played or not) and their description.
   init                        Creates a default configuration file.

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ This table will store the history of the migrations, do not delete it.
 5 commands are available with the VortexQL CLI.
 
 - `init` will initialise VortexQL and create a default configuration file.
-- `create` will create a new migration.
+- `create` will create a new migration. _Use `--mjs` option for '.mjs' file extension._
 - `list` will display a list & status (played or not played) of all the existing migrations.
 - `migrate` will execute all the non-played migrations.
 - `revert <version>` will revert the database to the version passed as the first argument.

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -21,11 +21,12 @@ program
 
 program
     .command('create')
-    .description('Creates a new migration')
-    .action(() => {
+    .description("Creates a new migration. [--mjs] option to use '.mjs' file extension.")
+    .addOption(new Option('--mjs', "use file extension '.mjs'"))
+    .action(({mjs}) => {
         Vortex.init();
 
-        Vortex.createNew();
+        Vortex.createNew(mjs);
         Vortex.finish();
     });
 

--- a/src/Vortex.js
+++ b/src/Vortex.js
@@ -161,13 +161,14 @@ Are you sure?`;
         }
     }
 
-    static createNew() {
+    static createNew(isMjs = false) {
         const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
         const template = path.join(__dirname + '/../data/migration.template.js');
         const content = fs.readFileSync(template).toString();
+        const fileExt = isMjs ? '.mjs' : '.js';
 
-        const newMigrationFileName = Date.now() + '.js';
+        const newMigrationFileName = Date.now() + fileExt;
         const migrationFilePath = path.join(FileSystemRepository.getMigrationFolderPath(), '/' + newMigrationFileName);
 
         fs.writeFileSync(migrationFilePath, content);

--- a/src/service/FileSystemRepository.js
+++ b/src/service/FileSystemRepository.js
@@ -49,7 +49,7 @@ export default class {
         const folderPath = this.getMigrationFolderPath();
 
         const migrationsPaths = fs.readdirSync(folderPath)
-            .filter((file) => file.endsWith('.js'))
+            .filter((file) => file.match(/\^*(\.m?(js))$/))
             .map((file) => {
                 const versionId = file.split('.')[0];
 


### PR DESCRIPTION
To support ESM migrations with `.js` file extensions, I needed to add a `type` property set to `module` in the `package.json` file, affecting the whole project.

`"type": "module"`

This PR adds support for optionally using migrations with `.mjs` file extensions instead.